### PR TITLE
Send Silently config option for Telegram messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This plugin provides a way to receive notifications on a Telegram chat when a pl
 3. Obtain a Telegram Bot API token and chat ID. Follow [these instructions](https://core.telegram.org/bots#how-do-i-create-a-bot) to create a bot and obtain the token, and [these instructions](https://stackoverflow.com/a/32572159) to obtain the chat ID.
 4. Set the `token` and `chatId` options in the `config.yml` file to the values obtained in step 3.
 5. Set the `prefix` option to a string that will be used as a prefix in the messages sent to the Telegram chat (optional).
+6. Set the `notifications.sendSilently` option to send notifications [silently](https://telegram.org/blog/channels-2-0#silent-messages)
 
 ## Usage
 

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/TelegramNotifier.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/TelegramNotifier.kt
@@ -21,7 +21,7 @@ class TelegramNotifier : JavaPlugin() {
         config = Config()
         saveDefaultConfig()
 
-        tg = Telegram(config.token, config.chatId, config.isNotificationsSendSilently)
+        tg = Telegram(config.token)
         notifications = Notifications()
         playersList = PlayersList()
         //init features

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/TelegramNotifier.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/TelegramNotifier.kt
@@ -21,7 +21,7 @@ class TelegramNotifier : JavaPlugin() {
         config = Config()
         saveDefaultConfig()
 
-        tg = Telegram(config.token)
+        tg = Telegram(config.token, config.chatId, config.isNotificationsSendSilently)
         notifications = Notifications()
         playersList = PlayersList()
         //init features

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/features/PlayersList.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/features/PlayersList.kt
@@ -27,21 +27,20 @@ class PlayersList() {
     }
 
     private fun sendNewMessageAndPin() {
-        val response = pluginInstance.tg.sendMessage(pluginInstance.config.chatId, text,false, ParseMode.MARKDOWN)
+        val response = pluginInstance.tg.sendMessage(text,false, ParseMode.MARKDOWN)
         if(response != null){
             val isOk = response["ok"].toString().toBooleanStrict()
             if (isOk) {
                 val resultObject = response["result"] as JSONObject
                 val messageId = resultObject["message_id"].toString().toInt()
                 pluginInstance.config.playersListMessageId = messageId
-                pluginInstance.tg.pinChatMessage(pluginInstance.config.chatId, messageId)
+                pluginInstance.tg.pinChatMessage(messageId)
             }
         }
     }
 
     private fun editMessage() {
         val response = pluginInstance.tg.editMessageText(
-            pluginInstance.config.chatId,
             pluginInstance.config.playersListMessageId,
             text,
             false,

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/features/PlayersList.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/features/PlayersList.kt
@@ -27,24 +27,34 @@ class PlayersList() {
     }
 
     private fun sendNewMessageAndPin() {
-        val response = pluginInstance.tg.sendMessage(text,false, ParseMode.MARKDOWN)
+        val response = pluginInstance.tg.sendMessage(
+                pluginInstance.config.chatId,
+                pluginInstance.config.isNotificationsSendSilently,
+                text, false, ParseMode.MARKDOWN
+        )
         if(response != null){
             val isOk = response["ok"].toString().toBooleanStrict()
             if (isOk) {
                 val resultObject = response["result"] as JSONObject
                 val messageId = resultObject["message_id"].toString().toInt()
                 pluginInstance.config.playersListMessageId = messageId
-                pluginInstance.tg.pinChatMessage(messageId)
+                pluginInstance.tg.pinChatMessage(
+                        pluginInstance.config.chatId,
+                        pluginInstance.config.isNotificationsSendSilently,
+                        messageId
+                )
             }
         }
     }
 
     private fun editMessage() {
         val response = pluginInstance.tg.editMessageText(
-            pluginInstance.config.playersListMessageId,
-            text,
-            false,
-            ParseMode.MARKDOWN
+                pluginInstance.config.chatId,
+                pluginInstance.config.isNotificationsSendSilently,
+                pluginInstance.config.playersListMessageId,
+                text,
+                false,
+                ParseMode.MARKDOWN
         )
         if(response != null){
             val isOk = response["ok"].toString().toBooleanStrict()

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/features/notifications/Notifications.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/features/notifications/Notifications.kt
@@ -11,7 +11,11 @@ class Notifications() {
         if (pluginInstance.config.isNotificationsPrefixEnabled) {
             text = pluginInstance.config.notificationsPrefixText + message
         }
-        pluginInstance.tg.sendMessage(text,false, null)
+        pluginInstance.tg.sendMessage(
+                pluginInstance.config.chatId,
+                pluginInstance.config.isNotificationsSendSilently,
+                text, false, null
+        )
     }
 
     fun send(type: NotificationTypes, player: Player){

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/features/notifications/Notifications.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/features/notifications/Notifications.kt
@@ -11,7 +11,7 @@ class Notifications() {
         if (pluginInstance.config.isNotificationsPrefixEnabled) {
             text = pluginInstance.config.notificationsPrefixText + message
         }
-        pluginInstance.tg.sendMessage(pluginInstance.config.chatId, text,false, null)
+        pluginInstance.tg.sendMessage(text,false, null)
     }
 
     fun send(type: NotificationTypes, player: Player){

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/utils/Config.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/utils/Config.kt
@@ -18,6 +18,8 @@ class Config() {
         get() = config.getBoolean("notifications.prefix.enabled")
     val notificationsPrefixText: String
         get() = config.getString("notifications.prefix.text")!!
+    val isNotificationsSendSilently: Boolean
+        get() = config.getBoolean("notifications.sendSilently")
     val isPlayersListEnabled: Boolean
         get() = config.getBoolean("playersList.enabled")
 

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/utils/telegram/Telegram.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/utils/telegram/Telegram.kt
@@ -7,13 +7,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.toString
 
-class Telegram(token: String, chatId: String, sendSilently: Boolean) {
+class Telegram(token: String) {
 
     private val request: Request = Request(String.format("https://api.telegram.org/bot%s/", token))
-    private val baseOptions: Map<String, String> = mapOf(
-            "chat_id" to chatId,
-            "disable_notification" to "$sendSilently"
-    )
 
     private fun handleErrors(response: JSONObject?) {
         if(response != null){
@@ -27,8 +23,13 @@ class Telegram(token: String, chatId: String, sendSilently: Boolean) {
         }
     }
 
-    fun sendMessage(text: String, webPreview: Boolean, parseMode: ParseMode?): JSONObject? {
-        val data = baseOptions.toMutableMap()
+    private fun baseRequestOptions(chatId: String, sendSilently: Boolean) = mutableMapOf(
+            "chat_id" to chatId,
+            "disable_notification" to "$sendSilently"
+    )
+
+    fun sendMessage(chatId: String, sendSilently: Boolean, text: String, webPreview: Boolean, parseMode: ParseMode?): JSONObject? {
+        val data = baseRequestOptions(chatId, sendSilently)
         data["text"] = text
         data["disable_web_page_preview"] = (!webPreview).toString()
         if (parseMode != null) {
@@ -40,8 +41,8 @@ class Telegram(token: String, chatId: String, sendSilently: Boolean) {
         return response
     }
 
-    fun editMessageText(messageId: Int, text: String, webPreview: Boolean, parseMode: ParseMode?): JSONObject? {
-        val data = baseOptions.toMutableMap()
+    fun editMessageText(chatId: String, sendSilently: Boolean, messageId: Int, text: String, webPreview: Boolean, parseMode: ParseMode?): JSONObject? {
+        val data = baseRequestOptions(chatId, sendSilently)
         data["message_id"] = "$messageId"
         data["text"] = text
         data["disable_web_page_preview"] = (!webPreview).toString()
@@ -54,8 +55,8 @@ class Telegram(token: String, chatId: String, sendSilently: Boolean) {
         return response
     }
 
-    fun pinChatMessage(messageId: Int): JSONObject? {
-        val data = baseOptions.toMutableMap()
+    fun pinChatMessage(chatId: String, sendSilently: Boolean, messageId: Int): JSONObject? {
+        val data = baseRequestOptions(chatId, sendSilently)
         data["message_id"] = "$messageId"
 
         val response = request.postJson("pinChatMessage", data)

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/utils/telegram/Telegram.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/utils/telegram/Telegram.kt
@@ -9,6 +9,13 @@ import kotlin.toString
 
 class Telegram(token: String) {
 
+    companion object {
+        private fun baseRequestOptions(chatId: String, sendSilently: Boolean) = mutableMapOf(
+                "chat_id" to chatId,
+                "disable_notification" to "$sendSilently"
+        )
+    }
+
     private val request: Request = Request(String.format("https://api.telegram.org/bot%s/", token))
 
     private fun handleErrors(response: JSONObject?) {
@@ -22,11 +29,6 @@ class Telegram(token: String) {
             }
         }
     }
-
-    private fun baseRequestOptions(chatId: String, sendSilently: Boolean) = mutableMapOf(
-            "chat_id" to chatId,
-            "disable_notification" to "$sendSilently"
-    )
 
     fun sendMessage(chatId: String, sendSilently: Boolean, text: String, webPreview: Boolean, parseMode: ParseMode?): JSONObject? {
         val data = baseRequestOptions(chatId, sendSilently)

--- a/src/main/kotlin/io/github/eone666/telegramnotifier/utils/telegram/Telegram.kt
+++ b/src/main/kotlin/io/github/eone666/telegramnotifier/utils/telegram/Telegram.kt
@@ -3,14 +3,17 @@ package io.github.eone666.telegramnotifier.utils.telegram
 import io.github.eone666.telegramnotifier.utils.Request
 import org.bukkit.Bukkit
 import org.json.simple.JSONObject
-import kotlin.Any
 import kotlin.Int
 import kotlin.String
 import kotlin.toString
 
-class Telegram(token: String) {
+class Telegram(token: String, chatId: String, sendSilently: Boolean) {
 
     private val request: Request = Request(String.format("https://api.telegram.org/bot%s/", token))
+    private val baseOptions: Map<String, String> = mapOf(
+            "chat_id" to chatId,
+            "disable_notification" to "$sendSilently"
+    )
 
     private fun handleErrors(response: JSONObject?) {
         if(response != null){
@@ -24,46 +27,37 @@ class Telegram(token: String) {
         }
     }
 
-    fun sendMessage(chatId: String, text: String, webPreview: Boolean, parseMode: ParseMode?): JSONObject? {
-        val data: Map<String, Any> = object : HashMap<String, Any>() {
-            init {
-                put("chat_id", chatId)
-                put("text", text)
-                put("disable_web_page_preview", !webPreview)
-                if(parseMode != null) {
-                    put("parse_mode", parseMode.toString())
-                }
-            }
+    fun sendMessage(text: String, webPreview: Boolean, parseMode: ParseMode?): JSONObject? {
+        val data = baseOptions.toMutableMap()
+        data["text"] = text
+        data["disable_web_page_preview"] = (!webPreview).toString()
+        if (parseMode != null) {
+            data["parse_mode"] = "$parseMode"
         }
+
         val response = request.postJson("sendMessage", data)
         handleErrors(response)
         return response
     }
 
-    fun editMessageText(chatId: String, messageId: Int, text: String, webPreview: Boolean, parseMode: ParseMode?): JSONObject? {
-        val data: Map<String, Any> = object : HashMap<String, Any>() {
-            init {
-                put("chat_id", chatId)
-                put("message_id", messageId)
-                put("text", text)
-                put("disable_web_page_preview", !webPreview)
-                if(parseMode != null) {
-                    put("parse_mode", parseMode.toString())
-                }
-            }
+    fun editMessageText(messageId: Int, text: String, webPreview: Boolean, parseMode: ParseMode?): JSONObject? {
+        val data = baseOptions.toMutableMap()
+        data["message_id"] = "$messageId"
+        data["text"] = text
+        data["disable_web_page_preview"] = (!webPreview).toString()
+        if (parseMode != null) {
+            data["parse_mode"] = "$parseMode"
         }
+
         val response = request.postJson("editMessageText", data)
         handleErrors(response)
         return response
     }
 
-    fun pinChatMessage(chatId: String, messageId: Int): JSONObject? {
-        val data: Map<String, Any> = object : HashMap<String, Any>() {
-            init {
-                put("chat_id", chatId)
-                put("message_id", messageId)
-            }
-        }
+    fun pinChatMessage(messageId: Int): JSONObject? {
+        val data = baseOptions.toMutableMap()
+        data["message_id"] = "$messageId"
+
         val response = request.postJson("pinChatMessage", data)
         handleErrors(response)
         return response

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,7 @@ notifications:
   playerJoin: false
   playerQuit: false
   playerAdvancement: false
+  sendSilently: false
   prefix:
     enabled: false
     text: "[Minecraft] "


### PR DESCRIPTION
Love the plugin! I wanted the notifications to be silent on my phone and you can do that by using the `disable_notification` API prop. https://core.telegram.org/bots/api#sendmessage

* The `baseOptions`, chatId and sendSilently are remove from the send, edit, and pin method parameters as they are common. I updated the constructor to include those additional params.
* Refactored away from using anonymous HashMaps and added a baseOptions for common telegram API properties.
* Updated README to include new sendSilently config option


I noticed you were initializing HashMaps with the anonymous class style. This can cause unnoticed side effects outlined in this [blog](https://blog.jooq.org/dont-be-clever-the-double-curly-braces-anti-pattern/).

I just converted them to use Kotlin's immutable maps and mutable maps were applicable, but happy to revert those changes if you want this PR to just adding the send silently prop.